### PR TITLE
Fix cstdint dependencies

### DIFF
--- a/ctlelem.hpp
+++ b/ctlelem.hpp
@@ -2,6 +2,7 @@
 #define CTLELEM_H
 
 #include <string>
+#include <cstdint>
 
 enum ctlflow{
 	CTL_INVALID, CTL_JMP, CTL_JCC, CTL_RET, CTL_LABEL, CTL_CALL

--- a/node.hpp
+++ b/node.hpp
@@ -4,6 +4,7 @@
 #include <set>
 #include <string>
 #include <map>
+#include <cstdint>
 
 typedef enum adj_type{
 	ADJ_CNT,


### PR DESCRIPTION
Updated ctlelem.hpp and node.hpp to include cstdint. This is required for uint32_t.